### PR TITLE
Updated the Calendar sample with a liquid layout.

### DIFF
--- a/plugins/calendarwidget/app/SampleTemplate.tpl
+++ b/plugins/calendarwidget/app/SampleTemplate.tpl
@@ -5,13 +5,20 @@
 		'light' : 'light.LightWidgetLib'
 	},
 	$css: ["app.css.SampleTemplateStyle"],
-	$hasScript: true
+	$hasScript: true,
+	$width:  {
+		min: 240	
+	},
+	$height: {
+		min: 200
+	}
 }}
 
 	{macro main()}
-
 			<!-- Control Panel Start -->
-			<div class="calendar-control-container">
+			{var leftBlockVisible = $width > 1275 && $height > 640 /}
+			{if leftBlockVisible}
+			<div class="calendar-control-container" style="display:inline-block; width:190px;vertical-align:top;height:${$vdim(90)}px;">
 				<div class="inputsContainer">
 					{@light:Calendar {
 						attributes : {
@@ -142,9 +149,10 @@
 					}/}
 						</div>
 					</div>
+					{/if}
 					<!-- Control Panel End -->
 
-					<div style="position:relative; width: 85%; height:800px; float: right;">
+					<div style="position:relative; vertical-align:top;display:inline-block; width: ${ leftBlockVisible ? $hdim(10,1) : $hdim(190,1) }px; height:${$vdim(180)}px;">
 						{@sample:Calendar{
 							moduleCtrl : {
 								classpath : "app.SampleModuleController",

--- a/plugins/calendarwidget/app/css/SampleTemplateStyle.tpl.css
+++ b/plugins/calendarwidget/app/css/SampleTemplateStyle.tpl.css
@@ -2,6 +2,10 @@
     $classpath: "app.css.SampleTemplateStyle"
 }}
 {macro main()}
+    textarea, select, input, button, table {
+        font-family: tahoma,arial,helvetica,sans-serif;
+        font-size: 11px;
+    }
 
     .calendar-control-container {
       display: inline-block;

--- a/plugins/calendarwidget/atplugins/calendarwidget/views/Calendar.tpl
+++ b/plugins/calendarwidget/atplugins/calendarwidget/views/Calendar.tpl
@@ -72,8 +72,8 @@
         id: "calendar-header",
         type: "table",
         attributes: {
-            "cellpadding": 0,
-            "cellspacing": 0,
+            "cellpadding": "0",
+            "cellspacing": "0",
             classList: ["calendar-header"]
         },
         macro: {

--- a/plugins/calendarwidget/index.html
+++ b/plugins/calendarwidget/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
-<html>
+<html lang="en">
     <head>
         <meta charset="utf-8">
         <meta content="IE=edge,chrome=1" http-equiv="X-UA-Compatible">
@@ -17,12 +17,13 @@
         <script type="text/javascript">
           var devMode = document.location.href.indexOf("devMode=true") != -1;
           if(devMode) {
-            document.write('<scr' + 'ipt language="JavaScript" src="http://cdn.ariatemplates.com/at1412.js?skin&dev"> </scri' + 'pt>');
+            document.write('<scr' + 'ipt language="JavaScript" src="http://cdn.ariatemplates.com/at149.js?skin&dev"> </scri' + 'pt>');
           } else {
-            document.write('<scr' + 'ipt language="JavaScript" src="http://cdn.ariatemplates.com/at1412.js?skin"> </scri' + 'pt>');
+            document.write('<scr' + 'ipt language="JavaScript" src="http://cdn.ariatemplates.com/at149.js?skin"> </scri' + 'pt>');
             document.write('<scr' + 'ipt language="JavaScript" src="atplugins.calendarwidget.js"> </scri' + 'pt>');
           }
         </script>
+        
         <script type="text/javascript">
           aria.core.AppEnvironment.setEnvironment({
             appSettings:{
@@ -35,10 +36,11 @@
         </script>
         
         <style>
-            body {
+            body, html {
                 margin: 0;
                 padding: 0;
                 background-color: #fafafa;
+                overflow: hidden;
             }
         </style>
     </head>
@@ -52,9 +54,15 @@
               Aria.loadTemplate({
                 classpath: "app.SampleTemplate",
                 div: "myApp",
+                rootDim: {
+                  width: {min:1},
+                  height: {min:1}
+                },
                 data: {
                   calendarData:{}
-                }
+                },
+                width: {min:1},
+                height: {min:1}
               });
         </script>
     </body>


### PR DESCRIPTION
This update includes:
- **A fix for**: some issues with IE when loading the calendar, and also issues with the calendar header section in multiple browsers.  These issues arise when using [version 1.4.10+ of Aria Templates](https://github.com/ariatemplates/ariatemplates/compare/v1.4.9...v1.4.10), as a result the calendar is currently supported by Aria Templates version 1.4.9
- **A liquid layout** for the calendar sample, now the sample supports multiple screen resolutions
