### PR TITLE
Calendar update: added a new property to configure the time increment in minutes.

### DIFF
--- a/plugins/calendarwidget/app/SampleModuleController.js
+++ b/plugins/calendarwidget/app/SampleModuleController.js
@@ -35,6 +35,7 @@ Aria.classDefinition({
                 eventEndTime : '0:00',
                 timeZone : "Europe/London",
                 lock : false,
+                interval : 15,
                 startDisplayHours: 6,
                 // from 0 to 23
                 startDisplayMinutes: 15,


### PR DESCRIPTION
There is now a new property <code>interval</code> which defaults to 15 minute increments between each calendar hour.  The property is optional and can be set to any integer that you wish events to be measured to.  The property affects the behaviour of editing events as well, including the drag and drop of event items, and the calculation of the event time displayed in the event item title.
